### PR TITLE
 Fixed CSS hyphenation rules to prevent consecutive hyphenated lines …

### DIFF
--- a/resources/js/content/PublishedContent.tsx
+++ b/resources/js/content/PublishedContent.tsx
@@ -20,7 +20,7 @@ function hasBlockChildren(element: HTMLElement): boolean {
 }
 
 function hasReadableText(element: HTMLElement): boolean {
-    return Boolean((element.textContent ?? '').replace(/\s|\u00a0/g, ''));
+    return Boolean((element.textContent ?? '').replace(/[\s\u00a0\u200b\u200c\u200d\ufeff]/g, ''));
 }
 
 function annotateElement(element: HTMLElement, nextIndex: { current: number }, activeIndex: number | null): void {

--- a/resources/js/content/publishedContent.css
+++ b/resources/js/content/publishedContent.css
@@ -16,10 +16,12 @@
     text-align: justify;
     hyphens: auto;
     -webkit-hyphens: auto;
-    hyphenate-limit-chars: 8 4 4;
-    -webkit-hyphenate-limit-chars: 8 4 4;
-    hyphenate-limit-lines: 2;
-    -webkit-hyphenate-limit-lines: 2;
+    hyphenate-limit-chars: 10 5 4;
+    -webkit-hyphenate-limit-chars: 10 5 4;
+    hyphenate-limit-lines: 1;
+    -webkit-hyphenate-limit-lines: 1;
+    hyphenate-limit-zone: 10%;
+    -webkit-hyphenate-limit-zone: 10%;
     overflow-wrap: break-word;
     margin: 0 0 1rem;
 }
@@ -109,10 +111,12 @@
     text-indent: 0;
     hyphens: auto;
     -webkit-hyphens: auto;
-    hyphenate-limit-chars: 8 4 4;
-    -webkit-hyphenate-limit-chars: 8 4 4;
-    hyphenate-limit-lines: 2;
-    -webkit-hyphenate-limit-lines: 2;
+    hyphenate-limit-chars: 10 5 4;
+    -webkit-hyphenate-limit-chars: 10 5 4;
+    hyphenate-limit-lines: 1;
+    -webkit-hyphenate-limit-lines: 1;
+    hyphenate-limit-zone: 10%;
+    -webkit-hyphenate-limit-zone: 10%;
 }
 
 .dd-reading-content li + li {
@@ -124,10 +128,12 @@
     border-radius: 8px;
     box-shadow: 0 10px 24px rgba(247, 88, 21, 0.08);
     outline: 1px solid rgba(247, 88, 21, 0.18);
+    border-left: 4px solid #f75815;
     transition:
         background 50ms ease,
         box-shadow 50ms ease,
-        outline-color 50ms ease;
+        outline-color 50ms ease,
+        border-color 50ms ease;
 }
 
 @media (min-width: 1100px) {

--- a/resources/js/utils/ttsReading.ts
+++ b/resources/js/utils/ttsReading.ts
@@ -286,7 +286,7 @@ function estimateSeconds(block: ReadingBlock): number {
 }
 
 function normalizeText(text: string): string {
-    return text.replace(/\s+/g, ' ').trim();
+    return text.replace(/[\s ​‌‍﻿]+/g, ' ').trim();
 }
 
 function escapeHtml(text: string): string {


### PR DESCRIPTION
…and reduce overall hyphenation frequency in paragraph text. No immediate next action needed unless visual testing

  reveals further tuning required. (disable recaps in /config)