### PR TITLE
[Hotfix] : widen cron window and cap overlap mutex TTL

### DIFF
--- a/resources/js/content/PublishedContent.tsx
+++ b/resources/js/content/PublishedContent.tsx
@@ -20,7 +20,7 @@ function hasBlockChildren(element: HTMLElement): boolean {
 }
 
 function hasReadableText(element: HTMLElement): boolean {
-    return Boolean((element.textContent ?? '').replace(/[\s\u00a0\u200b\u200c\u200d\ufeff]/g, ''));
+    return Boolean((element.textContent ?? '').replace(/\u200d|[\s\u00a0\u200b\u200c\ufeff]/g, ''));
 }
 
 function annotateElement(element: HTMLElement, nextIndex: { current: number }, activeIndex: number | null): void {

--- a/resources/js/utils/ttsReading.ts
+++ b/resources/js/utils/ttsReading.ts
@@ -286,7 +286,7 @@ function estimateSeconds(block: ReadingBlock): number {
 }
 
 function normalizeText(text: string): string {
-    return text.replace(/[\s ​‌‍﻿]+/g, ' ').trim();
+    return text.replace(/(?:\u200d|[\s\u00a0\u200b\u200c\ufeff])+/g, ' ').trim();
 }
 
 function escapeHtml(text: string): string {

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,15 +10,15 @@ Artisan::command('inspire', function () {
 
 // Corre cada minuto entre 6:00 y 6:10 los lunes, miércoles y viernes — notifica suscriptores del contenido publicado hoy.
 Schedule::command('devocional:notificar-diario')
-    ->cron('0-10 6 * * 1,3,5')
+    ->cron('0-59 6 * * 1,3,5')
     ->timezone('America/Bogota')
-    ->withoutOverlapping();
+    ->withoutOverlapping(10);
 
 // Corre cada minuto entre 3:00 y 3:10 AM los lunes, miércoles y viernes — publica contenido oculto programado para hoy y notifica por correo.
 Schedule::command('contenido:publicar-programado')
-    ->cron('0-10 3 * * 1,3,5')
+    ->cron('0-59 3 * * 1,3,5')
     ->timezone('America/Bogota')
-    ->withoutOverlapping();
+    ->withoutOverlapping(10);
 
 // Refuerza el cache de audios para contenido visible reciente; ignora voces ya generadas.
 Schedule::command('tts:pregenerate-devocionales --days=15')


### PR DESCRIPTION
Scheduler downtime during the 3am window caused contenido:publicar-programado to miss its entire execution slot. A concurrent deploy killed devocional:notificar-diario mid-run, leaving the withoutOverlapping mutex locked for 24h and blocking all retries within the same window.

- Extend both commands from 0-10 to 0-59 so a scheduler that recovers mid-hour still fires the command
- Set withoutOverlapping(10) so a killed process releases its mutex after 10 min instead of 24h