### PR TITLE
Evitar generación duplicada de audio TTS y agregar reintento automáti…

### DIFF
--- a/app/Console/Commands/GeneratePublishedDevocionalAudio.php
+++ b/app/Console/Commands/GeneratePublishedDevocionalAudio.php
@@ -46,7 +46,7 @@ class GeneratePublishedDevocionalAudio extends Command
             if ($this->option('sync')) {
                 (new GenerateDevocionalAudio($devocional->id))->handle($tts);
             } else {
-                GenerateDevocionalAudio::dispatch($devocional->id);
+                GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id);
             }
 
             $count++;

--- a/app/Console/Commands/PublicarContenidoProgramado.php
+++ b/app/Console/Commands/PublicarContenidoProgramado.php
@@ -41,7 +41,7 @@ class PublicarContenidoProgramado extends Command
 
         foreach ($publicados as $devocional) {
             $devocional->update(['hidden' => false]);
-            GenerateDevocionalAudio::dispatch($devocional->id);
+            GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id);
 
             // Ensure short_code exists
             if (! $devocional->short_code) {

--- a/app/Http/Controllers/DevocionalController.php
+++ b/app/Http/Controllers/DevocionalController.php
@@ -57,7 +57,7 @@ class DevocionalController extends Controller
     private function queueAudioIfVisible(Devocional $devocional): void
     {
         if (! $devocional->hidden) {
-            GenerateDevocionalAudio::dispatch($devocional->id)->afterCommit();
+            GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id);
         }
     }
 

--- a/app/Http/Controllers/TTSController.php
+++ b/app/Http/Controllers/TTSController.php
@@ -35,7 +35,7 @@ class TTSController extends Controller
                     $payload = $tts->cachedFromHtmlWithTimings($devocional->contenido ?? '', $lang, $voice, $rate);
 
                     if ($payload === null) {
-                        GenerateDevocionalAudio::dispatch($devocional->id);
+                        GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id);
 
                         return response()->json([
                             'ready' => false,

--- a/app/Jobs/GenerateDevocionalAudio.php
+++ b/app/Jobs/GenerateDevocionalAudio.php
@@ -19,6 +19,25 @@ class GenerateDevocionalAudio implements ShouldQueue
 
     public function __construct(private string $devocionalId) {}
 
+    public static function inProgressCacheKey(string $devocionalId): string
+    {
+        return "dilodepartededios:tts:devocional:{$devocionalId}:generating";
+    }
+
+    /**
+     * Dispatch a pregeneration job unless one is already running for this devocional.
+     * Prevents concurrent dispatches (e.g. an admin save + a visitor pressing Play)
+     * from piling up and fighting over the same cache lock.
+     */
+    public static function dispatchIfNotInProgress(string $devocionalId): void
+    {
+        if (Cache::has(self::inProgressCacheKey($devocionalId))) {
+            return;
+        }
+
+        self::dispatch($devocionalId)->afterCommit();
+    }
+
     public function handle(TextToSpeechService $tts): void
     {
         $devocional = Devocional::find($this->devocionalId);
@@ -30,6 +49,9 @@ class GenerateDevocionalAudio implements ShouldQueue
         if ($tts->plainTextFromHtml($devocional->contenido ?? '') === '') {
             return;
         }
+
+        $inProgressKey = self::inProgressCacheKey($devocional->id);
+        Cache::put($inProgressKey, true, $this->timeout);
 
         try {
             $lock = Cache::lock("dilodepartededios:tts:devocional:{$devocional->id}", 900);
@@ -87,6 +109,8 @@ class GenerateDevocionalAudio implements ShouldQueue
                 'id' => $devocional->id,
                 'message' => $exception->getMessage(),
             ]);
+        } finally {
+            Cache::forget($inProgressKey);
         }
     }
 }

--- a/resources/js/components/TextToSpeechButton.tsx
+++ b/resources/js/components/TextToSpeechButton.tsx
@@ -2,6 +2,8 @@ import { buildReadingTimings, extractReadingBlocks, findActiveReadingBlock, type
 import { useEffect, useRef, useState } from 'react';
 
 const LANG = 'es-CO';
+const POLL_INTERVAL_MS = 4000;
+const MAX_POLL_ATTEMPTS = 20; // ~80s before giving up
 
 const VOICES = [
     { label: 'Alonso (América)', value: 'es-US-AlonsoNeural', available: true, lang: 'es-US' },
@@ -36,6 +38,7 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
     const [rate, setRate] = useState(1);
     const [showSpeed, setShowSpeed] = useState(false);
     const [loading, setLoading] = useState(false);
+    const [preparing, setPreparing] = useState(false);
     const [audioUrl, setAudioUrl] = useState<string | null>(null);
     const [audioReady, setAudioReady] = useState(false);
     const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -116,26 +119,12 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
         emitBlockChange(active);
     };
 
-    const loadAudio = async (): Promise<boolean> => {
-        // Cancel any in-flight request before starting a new one
-        abortRef.current?.abort();
-        const controller = new AbortController();
-        abortRef.current = controller;
-
-        setLoading(true);
-        setAudioUrl(null);
-        setAudioReady(false);
-        setIsPlaying(false);
-        setIsPaused(false);
-        emitBlockChange(null);
-        blocksRef.current = extractReadingBlocks(html);
-        timingsRef.current = [];
-        hasServerTimingsRef.current = false;
-
-        const selectedVoiceConfig = VOICES.find((voice) => voice.value === selectedVoice);
-        const lang = selectedVoiceConfig?.lang ?? LANG;
-        const readingBlocks = blocksRef.current;
-
+    const requestAudio = async (
+        controller: AbortController,
+        lang: string,
+        readingBlocks: ReadingBlock[],
+        attempt: number,
+    ): Promise<boolean> => {
         try {
             const res = await fetch('/api/tts', {
                 method: 'POST',
@@ -162,6 +151,7 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
             if (!res.ok) {
                 const errorText = await res.text();
                 setLoading(false);
+                setPreparing(false);
                 setIsPlaying(false);
                 alert('Error generando el audio:\n' + errorText);
                 return false;
@@ -169,10 +159,22 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
             const data = await res.json() as TtsResponse;
 
             if (data.ready === false || !data.url) {
-                setLoading(false);
-                setIsPlaying(false);
-                alert(data.message ?? 'Audio en preparación. Intenta de nuevo en unos minutos.');
-                return false;
+                if (attempt + 1 >= MAX_POLL_ATTEMPTS) {
+                    setLoading(false);
+                    setPreparing(false);
+                    setIsPlaying(false);
+                    alert(data.message ?? 'El audio está tardando más de lo esperado. Intenta de nuevo en unos minutos.');
+                    return false;
+                }
+
+                setPreparing(true);
+                await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+                if (controller.signal.aborted) {
+                    return false;
+                }
+
+                return requestAudio(controller, lang, readingBlocks, attempt + 1);
             }
 
             const audioUrl = data.url.startsWith('http') ? data.url : window.location.origin + data.url;
@@ -182,6 +184,7 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
 
             if (!audio) {
                 setLoading(false);
+                setPreparing(false);
                 setIsPlaying(false);
                 return false;
             }
@@ -192,6 +195,7 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
             setServerTimings(data.timings, readingBlocks);
 
             setLoading(false);
+            setPreparing(false);
             setAudioReady(true);
             setIsPlaying(false);
             setIsPaused(false);
@@ -203,10 +207,35 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
                 return false;
             }
             setLoading(false);
+            setPreparing(false);
             setIsPlaying(false);
             alert('Error generando el audio.');
             return false;
         }
+    };
+
+    const loadAudio = async (): Promise<boolean> => {
+        // Cancel any in-flight request before starting a new one
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        setLoading(true);
+        setPreparing(false);
+        setAudioUrl(null);
+        setAudioReady(false);
+        setIsPlaying(false);
+        setIsPaused(false);
+        emitBlockChange(null);
+        blocksRef.current = extractReadingBlocks(html);
+        timingsRef.current = [];
+        hasServerTimingsRef.current = false;
+
+        const selectedVoiceConfig = VOICES.find((voice) => voice.value === selectedVoice);
+        const lang = selectedVoiceConfig?.lang ?? LANG;
+        const readingBlocks = blocksRef.current;
+
+        return requestAudio(controller, lang, readingBlocks, 0);
     };
 
     const handleMainClick = () => {
@@ -240,12 +269,14 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
 
     const handleStopClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
+        abortRef.current?.abort();
         audioRef.current?.pause();
         if (audioRef.current) audioRef.current.currentTime = 0;
         stopRaf();
         setIsPlaying(false);
         setIsPaused(false);
         setLoading(false);
+        setPreparing(false);
         setAudioReady(false);
         emitBlockChange(null);
     };
@@ -364,6 +395,12 @@ export default function TextToSpeechButton({ contentId, html, onBlockChange }: P
                 onPlay={() => { startRaf(); setIsPaused(false); }}
                 style={{ display: 'none' }}
             />
+
+            {preparing && (
+                <div style={{ textAlign: 'center', marginTop: 12, fontSize: '0.95em', color: '#6C63FF' }}>
+                    Generando audio… esto puede tardar hasta un minuto.
+                </div>
+            )}
 
             {audioReady && (
                 <div style={{ textAlign: 'center', marginTop: 12, fontSize: '0.95em', color: '#6C63FF' }}>


### PR DESCRIPTION
…co en Play

Los distintos disparadores de GenerateDevocionalAudio (guardar devocional, publicación programada, botón Play en cache-miss, backfill CLI) podían encolar varios jobs para el mismo devocional a la vez. El job en curso retiene el candado de generación hasta terminar (puede tardar minutos con 6 voces), y los duplicados fallaban tras esperar 5s el candado, registrando "Devocional audio pregeneration failed" aunque el original siguiera trabajando — dando la falsa impresión de fallo.

- GenerateDevocionalAudio::dispatchIfNotInProgress() marca un flag en caché mientras el job corre y evita despachar uno nuevo si ya hay uno en vuelo. Todos los call sites migrados a este método.
- TextToSpeechButton ya no muestra una alerta y abandona en el primer 202 "audio en preparación": ahora reintenta automáticamente cada 4s (hasta ~80s) mientras se genera, mostrando un mensaje de progreso.