### PR TITLE
Priorizar la voz solicitada en Play y reforzar reintentos de Azure TTS

### DIFF
--- a/app/Http/Controllers/TTSController.php
+++ b/app/Http/Controllers/TTSController.php
@@ -35,7 +35,7 @@ class TTSController extends Controller
                     $payload = $tts->cachedFromHtmlWithTimings($devocional->contenido ?? '', $lang, $voice, $rate);
 
                     if ($payload === null) {
-                        GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id);
+                        GenerateDevocionalAudio::dispatchIfNotInProgress($devocional->id, $lang, $voice);
 
                         return response()->json([
                             'ready' => false,

--- a/app/Jobs/GenerateDevocionalAudio.php
+++ b/app/Jobs/GenerateDevocionalAudio.php
@@ -17,7 +17,11 @@ class GenerateDevocionalAudio implements ShouldQueue
 
     public int $timeout = 900;
 
-    public function __construct(private string $devocionalId) {}
+    public function __construct(
+        private string $devocionalId,
+        private ?string $priorityLang = null,
+        private ?string $priorityVoice = null,
+    ) {}
 
     public static function inProgressCacheKey(string $devocionalId): string
     {
@@ -28,16 +32,24 @@ class GenerateDevocionalAudio implements ShouldQueue
      * Dispatch a pregeneration job unless one is already queued/running for this devocional.
      * Reserves the in-progress flag atomically at dispatch time (not job-start time) so two
      * dispatches racing while the first job is still sitting in the queue can't both get through.
+     *
+     * When $priorityLang/$priorityVoice are given (e.g. the voice a visitor is actively
+     * waiting on from the Play button), that pair is generated first instead of following
+     * the fixed voicePairs() order — otherwise a visitor waiting on the last voice in that
+     * list has to wait for all the others to finish (or time out/retry) first.
      */
-    public static function dispatchIfNotInProgress(string $devocionalId): void
-    {
+    public static function dispatchIfNotInProgress(
+        string $devocionalId,
+        ?string $priorityLang = null,
+        ?string $priorityVoice = null,
+    ): void {
         $reserved = Cache::add(self::inProgressCacheKey($devocionalId), true, 900);
 
         if (! $reserved) {
             return;
         }
 
-        self::dispatch($devocionalId)->afterCommit();
+        self::dispatch($devocionalId, $priorityLang, $priorityVoice)->afterCommit();
     }
 
     public function handle(TextToSpeechService $tts): void
@@ -61,7 +73,7 @@ class GenerateDevocionalAudio implements ShouldQueue
             $lock = Cache::lock("dilodepartededios:tts:devocional:{$devocional->id}", 900);
 
             $lock->block(5, function () use ($tts, $devocional) {
-                foreach ($tts->voicePairs() as $voicePair) {
+                foreach ($this->orderedVoicePairs($tts) as $voicePair) {
                     try {
                         $existing = $tts->cachedFromHtmlWithTimings(
                             $devocional->contenido ?? '',
@@ -116,5 +128,24 @@ class GenerateDevocionalAudio implements ShouldQueue
         } finally {
             Cache::forget($inProgressKey);
         }
+    }
+
+    /**
+     * @return array<int, array{lang: string, voice: string, label: string}>
+     */
+    private function orderedVoicePairs(TextToSpeechService $tts): array
+    {
+        $voicePairs = $tts->voicePairs();
+
+        if ($this->priorityLang === null || $this->priorityVoice === null) {
+            return $voicePairs;
+        }
+
+        $isPriority = fn (array $pair) => $pair['lang'] === $this->priorityLang && $pair['voice'] === $this->priorityVoice;
+
+        $priority = array_values(array_filter($voicePairs, $isPriority));
+        $rest = array_values(array_filter($voicePairs, fn (array $pair) => ! $isPriority($pair)));
+
+        return [...$priority, ...$rest];
     }
 }

--- a/app/Services/TextToSpeechService.php
+++ b/app/Services/TextToSpeechService.php
@@ -814,7 +814,12 @@ SSML;
     {
         try {
             return Http::timeout(30)
-                ->retry(2, 750, fn (\Exception $exception) => $exception instanceof ConnectionException, throw: false)
+                ->retry(
+                    4,
+                    fn (int $attempt) => $attempt * 600,
+                    fn (\Exception $exception) => $exception instanceof ConnectionException,
+                    throw: false,
+                )
                 ->withToken($token)
                 ->withHeaders([
                     'Content-Type' => 'application/ssml+xml',


### PR DESCRIPTION
El job de pregeneración siempre recorría las 6 combinaciones de voz en un orden fijo, sin saber cuál pidió el visitante desde el botón Play. Si la voz seleccionada caía al final de esa lista, el usuario esperaba a que se generaran (o fallaran y reintentaran) las otras 5 primero, superando fácilmente el tiempo de espera del frontend.

- GenerateDevocionalAudio ahora acepta un par lang/voice prioritario; TTSController se lo pasa cuando dispara el job por un cache-miss en Play, y el job reordena voicePairs() para generar esa voz primero.
- synthesize() pasa de 2 a 4 intentos con backoff creciente (600ms×n) ante errores de conexión, como medida defensiva contra los cortes intermitentes tipo "cURL error 18" observados con Azure Speech.