### PR TITLE
fix(tts): restore retry on ConnectionException in synthesize()

### DIFF
--- a/app/Services/TextToSpeechService.php
+++ b/app/Services/TextToSpeechService.php
@@ -832,7 +832,13 @@ SSML;
                     'attempt' => $attempt,
                 ]);
 
-                throw new \RuntimeException('No se pudo generar el audio porque el servidor no logró conectar con Azure Speech.');
+                if ($attempt === $maxAttempts) {
+                    throw new \RuntimeException('No se pudo generar el audio porque el servidor no logró conectar con Azure Speech.');
+                }
+
+                usleep(750 * $attempt * 1000);
+
+                continue;
             }
 
             if (! in_array($response->status(), [429, 500, 503], true) || $attempt === $maxAttempts) {


### PR DESCRIPTION
Merge conflict resolution dropped the connection-error retry path, so any Azure connect failure threw immediately with no backoff — same failure mode the throttle fix was meant to solve. Now both ConnectionException and 429/500/503 retry up to 4 attempts.


Claude-Session: https://claude.ai/code/session_01FudAKZq9aQhvMT1mVo3Y3i