### PR TITLE
feat: add devocional audio-folder calendar (365-day organizer)

### DIFF
--- a/app/Http/Controllers/DevocionalAudioFolderController.php
+++ b/app/Http/Controllers/DevocionalAudioFolderController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Devocional;
+use App\Services\DevocionalAudioFolderService;
+use App\Services\TextToSpeechService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use ZipArchive;
+
+class DevocionalAudioFolderController extends Controller
+{
+    public function index(DevocionalAudioFolderService $folders)
+    {
+        $counts = $folders->counts();
+
+        $summary = collect(DevocionalAudioFolderService::MONTH_NAMES)->map(fn (string $name, int $month) => [
+            'month' => $month,
+            'name' => $name,
+            'capacity' => DevocionalAudioFolderService::MONTH_CAPACITIES[$month],
+            'count' => (int) ($counts[$month] ?? 0),
+        ])->values();
+
+        return Inertia::render('DevocionalAudioFolders', [
+            'folders' => $summary,
+            'totalCapacity' => array_sum(DevocionalAudioFolderService::MONTH_CAPACITIES),
+            'totalAssigned' => array_sum($counts),
+        ]);
+    }
+
+    public function generate(DevocionalAudioFolderService $folders)
+    {
+        $assigned = $folders->fillGaps();
+
+        return back()->with('status', $assigned > 0
+            ? "Se asignaron {$assigned} devocionales a las carpetas."
+            : 'No hay devocionales nuevos para asignar (o las 12 carpetas ya están completas).');
+    }
+
+    public function show(int $month, TextToSpeechService $tts)
+    {
+        abort_unless(array_key_exists($month, DevocionalAudioFolderService::MONTH_NAMES), 404);
+
+        $devocionales = Devocional::inAudioFolder($month)->get();
+
+        $items = $devocionales->map(fn (Devocional $devocional) => [
+            'id' => $devocional->id,
+            'position' => $devocional->audio_folder_position,
+            'categoria' => $devocional->categoria,
+            'autor' => $devocional->autor,
+            'imagen' => $devocional->imagen,
+            'titulo' => $this->titleFromHtml($devocional->contenido ?? ''),
+            'views_count' => $devocional->views_count,
+            'filename' => $tts->filenameFromHtml($devocional->contenido ?? '', "devocional-{$devocional->audio_folder_position}"),
+        ]);
+
+        $todasLasCategorias = Devocional::whereNotNull('categoria')
+            ->where('categoria', '!=', '')
+            ->distinct()
+            ->pluck('categoria')
+            ->map(fn (string $categoria) => strtolower(trim($categoria)))
+            ->sort()
+            ->values();
+
+        $monthOptions = collect(DevocionalAudioFolderService::MONTH_NAMES)->map(fn (string $name, int $m) => [
+            'month' => $m,
+            'name' => $name,
+        ])->values();
+
+        return Inertia::render('DevocionalAudioFolderDetail', [
+            'month' => $month,
+            'monthName' => DevocionalAudioFolderService::MONTH_NAMES[$month],
+            'capacity' => DevocionalAudioFolderService::MONTH_CAPACITIES[$month],
+            'items' => $items,
+            'voicePairs' => $tts->voicePairs(),
+            'todasLasCategorias' => $todasLasCategorias,
+            'monthOptions' => $monthOptions,
+        ]);
+    }
+
+    public function move(Request $request, DevocionalAudioFolderService $folders)
+    {
+        $validated = $request->validate([
+            'id' => 'required|uuid',
+            'month' => 'required|integer|min:1|max:12',
+        ]);
+
+        $devocional = Devocional::soloDevocionales()->findOrFail($validated['id']);
+
+        try {
+            $folders->move($devocional, (int) $validated['month']);
+        } catch (\RuntimeException $exception) {
+            return response()->json(['message' => $exception->getMessage()], 422);
+        }
+
+        return response()->json(['ok' => true]);
+    }
+
+    /**
+     * Mirrors the frontend's obtenerPrimerEtiqueta(): first HTML tag's text
+     * content, used app-wide as the display title (devocionales have no
+     * dedicated title column).
+     */
+    private function titleFromHtml(string $html): string
+    {
+        $decoded = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        if (preg_match('/<([a-zA-Z0-9]+)[^>]*>(.*?)<\/\1>/i', $decoded, $matches)) {
+            return trim(strip_tags($matches[2]));
+        }
+
+        return '';
+    }
+
+    public function downloadAudio(string $id, Request $request, TextToSpeechService $tts)
+    {
+        $devocional = Devocional::soloDevocionales()->findOrFail($id);
+        [$lang, $voice] = $this->voiceFromRequest($request, $tts);
+
+        $tts->generateFromHtml($devocional->contenido ?? '', $lang, $voice);
+        $path = $tts->pathForHtml($devocional->contenido ?? '', $lang, $voice);
+
+        if (! $path || ! Storage::disk('s3')->exists($path)) {
+            abort(404, 'Audio no disponible');
+        }
+
+        $filename = $tts->filenameFromHtml($devocional->contenido ?? '', 'devocional');
+
+        return response(Storage::disk('s3')->get($path), 200, [
+            'Content-Type' => 'audio/mpeg',
+            'Content-Disposition' => "attachment; filename=\"{$filename}.mp3\"",
+        ]);
+    }
+
+    public function audioUrl(string $id, Request $request, TextToSpeechService $tts)
+    {
+        $devocional = Devocional::soloDevocionales()->findOrFail($id);
+        [$lang, $voice] = $this->voiceFromRequest($request, $tts);
+
+        $url = $tts->generateFromHtml($devocional->contenido ?? '', $lang, $voice);
+
+        return response()->json(['url' => $url]);
+    }
+
+    public function downloadZip(int $month, Request $request, TextToSpeechService $tts)
+    {
+        abort_unless(array_key_exists($month, DevocionalAudioFolderService::MONTH_NAMES), 404);
+
+        [$lang, $voice] = $this->voiceFromRequest($request, $tts);
+
+        $devocionales = Devocional::inAudioFolder($month)->get();
+        abort_if($devocionales->isEmpty(), 404, 'La carpeta está vacía');
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'devocionales-zip-');
+        $zip = new ZipArchive();
+        $zip->open($tmpPath, ZipArchive::OVERWRITE);
+
+        $usedNames = [];
+
+        foreach ($devocionales as $devocional) {
+            $tts->generateFromHtml($devocional->contenido ?? '', $lang, $voice);
+            $path = $tts->pathForHtml($devocional->contenido ?? '', $lang, $voice);
+
+            if (! $path || ! Storage::disk('s3')->exists($path)) {
+                continue;
+            }
+
+            $baseName = sprintf('%02d-%s', $devocional->audio_folder_position, $tts->filenameFromHtml($devocional->contenido ?? '', "devocional-{$devocional->audio_folder_position}"));
+            $entryName = $baseName;
+            $suffix = 1;
+            while (isset($usedNames[$entryName])) {
+                $entryName = "{$baseName}-{$suffix}";
+                $suffix++;
+            }
+            $usedNames[$entryName] = true;
+
+            $zip->addFromString("{$entryName}.mp3", Storage::disk('s3')->get($path));
+        }
+
+        $zip->close();
+
+        $monthName = DevocionalAudioFolderService::MONTH_NAMES[$month];
+
+        return response()->download($tmpPath, "{$monthName}.zip", [
+            'Content-Type' => 'application/zip',
+        ])->deleteFileAfterSend(true);
+    }
+
+    /** @return array{0: string, 1: string} */
+    private function voiceFromRequest(Request $request, TextToSpeechService $tts): array
+    {
+        $lang = (string) $request->query('lang', 'es-MX');
+        $voice = (string) $request->query('voice', '');
+
+        $valid = collect($tts->voicePairs())->first(fn (array $pair) => $pair['lang'] === $lang && $pair['voice'] === $voice);
+
+        if (! $valid) {
+            $fallback = $tts->voicePairs()[0] ?? ['lang' => 'es-MX', 'voice' => 'es-MX-DaliaNeural'];
+
+            return [$fallback['lang'], $fallback['voice']];
+        }
+
+        return [$lang, $voice];
+    }
+}

--- a/app/Models/Devocional.php
+++ b/app/Models/Devocional.php
@@ -28,6 +28,8 @@ class Devocional extends Model
         'notificado_at',
         'short_code',
         'shares_count',
+        'audio_folder_month',
+        'audio_folder_position',
     ];
 
     // PK UUID string
@@ -35,9 +37,11 @@ class Devocional extends Model
     protected $keyType = 'string';
 
     protected $casts = [
-        'is_devocional' => 'integer',
-        'hidden'        => 'boolean',
-        'created_at'    => 'datetime',
+        'is_devocional'          => 'integer',
+        'hidden'                 => 'boolean',
+        'created_at'             => 'datetime',
+        'audio_folder_month'     => 'integer',
+        'audio_folder_position'  => 'integer',
     ];
 
     protected static function boot()
@@ -47,6 +51,15 @@ class Devocional extends Model
         static::creating(function ($model) {
             if (! $model->id) {
                 $model->id = (string) Str::uuid();
+            }
+        });
+
+        // Auto-incorporates new devocionales into the audio-folder calendar
+        // (next open slot, January first) so the admin only needs to run the
+        // "fill gaps" backfill once for pre-existing content.
+        static::created(function (Devocional $model) {
+            if ($model->is_devocional === self::TYPE_DEVOCIONAL && $model->audio_folder_month === null) {
+                app(\App\Services\DevocionalAudioFolderService::class)->assignNext($model);
             }
         });
     }
@@ -63,6 +76,21 @@ class Devocional extends Model
     public function scopeSoloEnsenanzas($query)
     {
         return $query->where('is_devocional', self::TYPE_SERIE);
+    }
+
+    public function scopeSoloDevocionales($query)
+    {
+        return $query->where('is_devocional', self::TYPE_DEVOCIONAL);
+    }
+
+    /**
+     * Scope: devocionales asignados a una carpeta de audio mensual, en orden de posición.
+     */
+    public function scopeInAudioFolder($query, int $month)
+    {
+        return $query->where('is_devocional', self::TYPE_DEVOCIONAL)
+            ->where('audio_folder_month', $month)
+            ->orderBy('audio_folder_position');
     }
 
     /**

--- a/app/Services/DevocionalAudioFolderService.php
+++ b/app/Services/DevocionalAudioFolderService.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Devocional;
+use Illuminate\Support\Facades\DB;
+
+class DevocionalAudioFolderService
+{
+    /** @var array<int, int> Month (1-12) => number of slots, mirrors the calendar (non-leap February). */
+    public const MONTH_CAPACITIES = [
+        1 => 31, 2 => 28, 3 => 31, 4 => 30, 5 => 31, 6 => 30,
+        7 => 31, 8 => 31, 9 => 30, 10 => 31, 11 => 30, 12 => 31,
+    ];
+
+    /** @var array<int, string> */
+    public const MONTH_NAMES = [
+        1 => 'Enero', 2 => 'Febrero', 3 => 'Marzo', 4 => 'Abril', 5 => 'Mayo', 6 => 'Junio',
+        7 => 'Julio', 8 => 'Agosto', 9 => 'Septiembre', 10 => 'Octubre', 11 => 'Noviembre', 12 => 'Diciembre',
+    ];
+
+    /** @return array<int, int> month => assigned count */
+    public function counts(): array
+    {
+        return Devocional::soloDevocionales()
+            ->whereNotNull('audio_folder_month')
+            ->selectRaw('audio_folder_month, count(*) as total')
+            ->groupBy('audio_folder_month')
+            ->pluck('total', 'audio_folder_month')
+            ->all();
+    }
+
+    /**
+     * One-time backfill: assigns every unassigned devocional to the next open
+     * slot, filling January first, then February, etc. Safe to call again —
+     * it only ever touches rows that still have no folder.
+     */
+    public function fillGaps(): int
+    {
+        $assigned = 0;
+
+        DB::transaction(function () use (&$assigned) {
+            $counts = Devocional::soloDevocionales()
+                ->whereNotNull('audio_folder_month')
+                ->selectRaw('audio_folder_month, count(*) as total')
+                ->groupBy('audio_folder_month')
+                ->lockForUpdate()
+                ->pluck('total', 'audio_folder_month');
+
+            $pool = Devocional::soloDevocionales()
+                ->whereNull('audio_folder_month')
+                ->inRandomOrder()
+                ->pluck('id')
+                ->all();
+
+            foreach (self::MONTH_CAPACITIES as $month => $capacity) {
+                $current = (int) ($counts[$month] ?? 0);
+                $remaining = $capacity - $current;
+
+                if ($remaining <= 0 || empty($pool)) {
+                    continue;
+                }
+
+                $slice = array_splice($pool, 0, $remaining);
+                $position = $current;
+
+                foreach ($slice as $id) {
+                    $position++;
+                    Devocional::where('id', $id)->update([
+                        'audio_folder_month' => $month,
+                        'audio_folder_position' => $position,
+                    ]);
+                    $assigned++;
+                }
+            }
+        });
+
+        return $assigned;
+    }
+
+    /**
+     * Appends a single freshly-created devocional to the next open slot
+     * (January first, then February, ...). Called automatically on create
+     * so new content keeps filling the calendar without re-running fillGaps().
+     */
+    public function assignNext(Devocional $devocional): void
+    {
+        if ($devocional->audio_folder_month !== null) {
+            return;
+        }
+
+        DB::transaction(function () use ($devocional) {
+            $counts = Devocional::soloDevocionales()
+                ->whereNotNull('audio_folder_month')
+                ->selectRaw('audio_folder_month, count(*) as total')
+                ->groupBy('audio_folder_month')
+                ->lockForUpdate()
+                ->pluck('total', 'audio_folder_month');
+
+            foreach (self::MONTH_CAPACITIES as $month => $capacity) {
+                $current = (int) ($counts[$month] ?? 0);
+
+                if ($current < $capacity) {
+                    $devocional->forceFill([
+                        'audio_folder_month' => $month,
+                        'audio_folder_position' => $current + 1,
+                    ])->save();
+
+                    return;
+                }
+            }
+            // All 12 folders full (365 reached) — leave unassigned.
+        });
+    }
+
+    /**
+     * Moves a devocional to a different month folder, appended at the end.
+     * Closes the gap left behind in its previous month, if any.
+     *
+     * @throws \RuntimeException if the target folder is already full
+     */
+    public function move(Devocional $devocional, int $targetMonth): void
+    {
+        if (! array_key_exists($targetMonth, self::MONTH_CAPACITIES)) {
+            throw new \InvalidArgumentException('Mes inválido.');
+        }
+
+        DB::transaction(function () use ($devocional, $targetMonth) {
+            $oldMonth = $devocional->audio_folder_month;
+            $oldPosition = $devocional->audio_folder_position;
+
+            if ($oldMonth === $targetMonth) {
+                return;
+            }
+
+            $targetCount = Devocional::soloDevocionales()
+                ->where('audio_folder_month', $targetMonth)
+                ->lockForUpdate()
+                ->count();
+
+            if ($targetCount >= self::MONTH_CAPACITIES[$targetMonth]) {
+                throw new \RuntimeException('La carpeta destino ya está completa.');
+            }
+
+            // Vacate the old slot first so the gap-closing shift below never
+            // collides with the (month, position) unique constraint.
+            $devocional->forceFill([
+                'audio_folder_month' => $targetMonth,
+                'audio_folder_position' => $targetCount + 1,
+            ])->save();
+
+            if ($oldMonth === null) {
+                return;
+            }
+
+            $trailing = Devocional::soloDevocionales()
+                ->where('audio_folder_month', $oldMonth)
+                ->where('audio_folder_position', '>', $oldPosition)
+                ->orderBy('audio_folder_position')
+                ->get(['id', 'audio_folder_position']);
+
+            foreach ($trailing as $row) {
+                Devocional::where('id', $row->id)->update([
+                    'audio_folder_position' => $row->audio_folder_position - 1,
+                ]);
+            }
+        });
+    }
+}

--- a/app/Services/TextToSpeechService.php
+++ b/app/Services/TextToSpeechService.php
@@ -120,6 +120,19 @@ class TextToSpeechService
         return Str::of($text)->squish()->toString();
     }
 
+    /**
+     * Derives a filesystem-safe filename from the first words of the content,
+     * for use when downloading audio (devocionals have no title field).
+     */
+    public function filenameFromHtml(string $html, string $fallback = 'devocional'): string
+    {
+        $text = $this->plainTextFromHtml($html);
+        $snippet = Str::of($text)->limit(50, '')->toString();
+        $slug = Str::slug($snippet);
+
+        return $slug !== '' ? $slug : $fallback;
+    }
+
     public function generateFromHtml(
         string $html,
         string $lang = 'es-CO',
@@ -292,6 +305,15 @@ class TextToSpeechService
 
             return $url;
         });
+    }
+
+    public function pathForHtml(
+        string $html,
+        string $lang = 'es-CO',
+        string $voice = 'es-CO-SalomeNeural',
+        int $rate = 0
+    ): ?string {
+        return $this->pathForText($this->speechTextFromHtml($html), $lang, $voice, $rate);
     }
 
     public function pathForText(

--- a/database/migrations/2026_07_15_000001_add_audio_folder_to_devocionals_table.php
+++ b/database/migrations/2026_07_15_000001_add_audio_folder_to_devocionals_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devocionals', function (Blueprint $table) {
+            $table->unsignedTinyInteger('audio_folder_month')->nullable()->after('shares_count');
+            $table->unsignedTinyInteger('audio_folder_position')->nullable()->after('audio_folder_month');
+            $table->unique(['audio_folder_month', 'audio_folder_position'], 'devocionals_audio_folder_slot_unique');
+            $table->index(['is_devocional', 'audio_folder_month'], 'devocionals_audio_folder_month_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devocionals', function (Blueprint $table) {
+            $table->dropUnique('devocionals_audio_folder_slot_unique');
+            $table->dropIndex('devocionals_audio_folder_month_idx');
+            $table->dropColumn(['audio_folder_month', 'audio_folder_position']);
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,7 +4,7 @@ import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Edit3, Image, LayoutGrid, PlusCircle, Trash2 } from 'lucide-react';
+import { BookOpen, Edit3, FolderOpen, Image, LayoutGrid, PlusCircle, Trash2 } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -32,6 +32,11 @@ const mainNavItems: NavItem[] = [
         title: 'Limpiar bucket',
         href: '/storage-cleanup',
         icon: Trash2,
+    },
+    {
+        title: 'Carpetas de audio',
+        href: '/devocionales-audio-folders',
+        icon: FolderOpen,
     },
 ];
 

--- a/resources/js/pages/DevocionalAudioFolderDetail.tsx
+++ b/resources/js/pages/DevocionalAudioFolderDetail.tsx
@@ -1,0 +1,254 @@
+import CardNew from '@/components/CardNew';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { router } from '@inertiajs/react';
+import { Download, FileArchive, Loader2, Play } from 'lucide-react';
+import { useState } from 'react';
+import '../../css/admin-edit.css';
+import '../../css/cardNew.css';
+
+interface VoicePair {
+    lang: string;
+    voice: string;
+    label: string;
+}
+
+interface FolderItem {
+    id: string;
+    position: number;
+    categoria: string | null;
+    autor: string | null;
+    imagen: string | null;
+    titulo: string;
+    views_count: number | null;
+    filename: string;
+}
+
+interface MonthOption {
+    month: number;
+    name: string;
+}
+
+interface Props {
+    month: number;
+    monthName: string;
+    capacity: number;
+    items: FolderItem[];
+    voicePairs: VoicePair[];
+    todasLasCategorias: string[];
+    monthOptions: MonthOption[];
+}
+
+function voiceKey(lang: string, voice: string): string {
+    return `${lang}|${voice}`;
+}
+
+function csrfToken(): string {
+    return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+}
+
+export default function DevocionalAudioFolderDetail({ month, monthName, capacity, items, voicePairs, todasLasCategorias, monthOptions }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Dashboard', href: '/dashboard' },
+        { title: 'Carpetas de audio', href: '/devocionales-audio-folders' },
+        { title: monthName, href: `/devocionales-audio-folders/${month}` },
+    ];
+
+    const defaultPair = voicePairs[0] ?? { lang: 'es-MX', voice: 'es-MX-DaliaNeural', label: 'Dalia' };
+    const [selectedKey, setSelectedKey] = useState(voiceKey(defaultPair.lang, defaultPair.voice));
+    const [lang, voice] = selectedKey.split('|');
+
+    const [audioUrls, setAudioUrls] = useState<Record<string, string>>({});
+    const [loadingId, setLoadingId] = useState<string | null>(null);
+    const [zipLoading, setZipLoading] = useState(false);
+    const [moveTargets, setMoveTargets] = useState<Record<string, number>>({});
+    const [movingId, setMovingId] = useState<string | null>(null);
+
+    const playCardKey = (id: string) => `${id}|${selectedKey}`;
+
+    const loadAudio = async (id: string) => {
+        const cacheKey = playCardKey(id);
+        if (audioUrls[cacheKey]) return;
+
+        setLoadingId(id);
+        try {
+            const res = await fetch(`/devocionales-audio-folders-audio/${id}/url?lang=${lang}&voice=${voice}`);
+            const data = (await res.json()) as { url: string };
+            setAudioUrls((prev) => ({ ...prev, [cacheKey]: data.url }));
+        } finally {
+            setLoadingId(null);
+        }
+    };
+
+    const downloadZip = () => {
+        setZipLoading(true);
+        window.location.href = `/devocionales-audio-folders/${month}/zip?lang=${lang}&voice=${voice}`;
+        setTimeout(() => setZipLoading(false), 3000);
+    };
+
+    const moveItem = async (id: string) => {
+        const target = moveTargets[id];
+        if (!target || target === month) return;
+
+        setMovingId(id);
+        try {
+            const res = await fetch('/devocionales-audio-folders/move', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-TOKEN': csrfToken(),
+                },
+                body: JSON.stringify({ id, month: target }),
+            });
+
+            if (!res.ok) {
+                const data = (await res.json().catch(() => null)) as { message?: string } | null;
+                alert(data?.message ?? 'No se pudo mover el devocional.');
+                return;
+            }
+
+            router.reload({ only: ['items', 'capacity'] });
+        } finally {
+            setMovingId(null);
+        }
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <div className="flex flex-col gap-6 p-3 sm:p-5 md:p-7" style={{ backgroundColor: '#f5f0e8', minHeight: '100vh' }}>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold" style={{ color: '#2d465e', fontFamily: "'Cormorant Garamond', serif" }}>
+                            {monthName}
+                        </h1>
+                        <p className="mt-1 text-sm" style={{ color: '#8a7f72' }}>
+                            {items.length} de {capacity} devocionales
+                        </p>
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <select
+                            value={selectedKey}
+                            onChange={(e) => {
+                                setSelectedKey(e.target.value);
+                            }}
+                            className="rounded-xl border px-3 py-2 text-sm"
+                            style={{ borderColor: '#e8e2d8', backgroundColor: '#fff', color: '#2d465e' }}
+                        >
+                            {voicePairs.map((pair) => (
+                                <option key={voiceKey(pair.lang, pair.voice)} value={voiceKey(pair.lang, pair.voice)}>
+                                    {pair.label}
+                                </option>
+                            ))}
+                        </select>
+
+                        <button
+                            onClick={downloadZip}
+                            disabled={zipLoading || items.length === 0}
+                            className="flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-opacity disabled:opacity-50"
+                            style={{ backgroundColor: '#f75815', color: '#fff' }}
+                        >
+                            {zipLoading ? <Loader2 size={14} className="animate-spin" /> : <FileArchive size={14} />}
+                            Descargar ZIP
+                        </button>
+                    </div>
+                </div>
+
+                {items.length === 0 && (
+                    <div
+                        className="flex flex-col items-center justify-center rounded-2xl border py-20 text-center"
+                        style={{ backgroundColor: '#fff', borderColor: '#e8e2d8' }}
+                    >
+                        <p className="font-semibold" style={{ color: '#2d465e' }}>
+                            Carpeta vacía
+                        </p>
+                        <p className="mt-1 text-sm" style={{ color: '#8a7f72' }}>
+                            Volvé a la lista de carpetas y usá "Rellenar carpetas" para asignar devocionales.
+                        </p>
+                    </div>
+                )}
+
+                <div className="ae-grid">
+                    {items.map((item) => {
+                        const cacheKey = playCardKey(item.id);
+                        const url = audioUrls[cacheKey];
+                        const isLoading = loadingId === item.id;
+                        const isMoving = movingId === item.id;
+
+                        return (
+                            <div key={item.id} className="ae-card-wrap">
+                                <CardNew
+                                    dev={{
+                                        id: item.id,
+                                        imagen: item.imagen ?? '',
+                                        titulo: item.titulo,
+                                        autor: item.autor ?? '',
+                                        categoria: item.categoria ?? '',
+                                        views_count: item.views_count ?? 0,
+                                        is_devocional: 1,
+                                    }}
+                                    todasLasCategorias={todasLasCategorias}
+                                    onClick={() => window.open(`/devocional/${item.id}`, '_blank')}
+                                />
+
+                                <div className="ae-card-actions">
+                                    <span className="ae-card-btn" style={{ background: '#f5f0e8', color: '#2d465e', flex: '0 0 auto' }}>
+                                        #{item.position}
+                                    </span>
+
+                                    {url ? (
+                                        <audio controls autoPlay src={url} style={{ flex: 1, height: 30 }} />
+                                    ) : (
+                                        <button
+                                            onClick={() => loadAudio(item.id)}
+                                            disabled={isLoading}
+                                            className="ae-card-btn ae-card-btn--view"
+                                        >
+                                            {isLoading ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />}
+                                            {isLoading ? 'Generando…' : 'Reproducir'}
+                                        </button>
+                                    )}
+
+                                    <a
+                                        href={`/devocionales-audio-folders-audio/${item.id}?lang=${lang}&voice=${voice}`}
+                                        className="ae-card-btn ae-card-btn--edit"
+                                        style={{ flex: '0 0 auto' }}
+                                    >
+                                        <Download size={11} />
+                                    </a>
+                                </div>
+
+                                <div className="ae-card-actions">
+                                    <select
+                                        value={moveTargets[item.id] ?? ''}
+                                        onChange={(e) => setMoveTargets((prev) => ({ ...prev, [item.id]: Number(e.target.value) }))}
+                                        className="ae-card-btn"
+                                        style={{ background: '#fff', color: '#2d465e', border: '1px solid #e8e2d8', fontWeight: 500 }}
+                                    >
+                                        <option value="">Mover a…</option>
+                                        {monthOptions
+                                            .filter((opt) => opt.month !== month)
+                                            .map((opt) => (
+                                                <option key={opt.month} value={opt.month}>
+                                                    {opt.name}
+                                                </option>
+                                            ))}
+                                    </select>
+                                    <button
+                                        onClick={() => moveItem(item.id)}
+                                        disabled={isMoving || !moveTargets[item.id]}
+                                        className="ae-card-btn ae-card-btn--hide"
+                                        style={{ flex: '0 0 auto' }}
+                                    >
+                                        {isMoving ? <Loader2 size={11} className="animate-spin" /> : 'OK'}
+                                    </button>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/DevocionalAudioFolders.tsx
+++ b/resources/js/pages/DevocionalAudioFolders.tsx
@@ -1,0 +1,107 @@
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Link, router } from '@inertiajs/react';
+import { Folder, Shuffle } from 'lucide-react';
+import { useState } from 'react';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Dashboard', href: '/dashboard' },
+    { title: 'Carpetas de audio', href: '/devocionales-audio-folders' },
+];
+
+interface FolderSummary {
+    month: number;
+    name: string;
+    capacity: number;
+    count: number;
+}
+
+interface Props {
+    folders: FolderSummary[];
+    totalCapacity: number;
+    totalAssigned: number;
+}
+
+export default function DevocionalAudioFolders({ folders, totalCapacity, totalAssigned }: Props) {
+    const [generating, setGenerating] = useState(false);
+
+    const generate = () => {
+        setGenerating(true);
+        router.post(
+            '/devocionales-audio-folders/generate',
+            {},
+            {
+                preserveScroll: true,
+                onFinish: () => setGenerating(false),
+            },
+        );
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <div className="flex flex-col gap-6 p-3 sm:p-5 md:p-7" style={{ backgroundColor: '#f5f0e8', minHeight: '100vh' }}>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold" style={{ color: '#2d465e', fontFamily: "'Cormorant Garamond', serif" }}>
+                            Carpetas de audio
+                        </h1>
+                        <p className="mt-1 text-sm" style={{ color: '#8a7f72' }}>
+                            {totalAssigned} de {totalCapacity} devocionales asignados
+                        </p>
+                    </div>
+
+                    <button
+                        onClick={generate}
+                        disabled={generating}
+                        className="flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-opacity disabled:opacity-50"
+                        style={{ backgroundColor: '#f75815', color: '#fff' }}
+                    >
+                        <Shuffle size={14} className={generating ? 'animate-spin' : ''} />
+                        {generating ? 'Agrupando…' : 'Rellenar carpetas'}
+                    </button>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {folders.map((folder) => {
+                        const full = folder.count >= folder.capacity;
+
+                        return (
+                            <Link
+                                key={folder.month}
+                                href={`/devocionales-audio-folders/${folder.month}`}
+                                className="flex flex-col gap-3 rounded-2xl border p-4 transition-all hover:shadow-md"
+                                style={{ backgroundColor: '#fff', borderColor: '#e8e2d8' }}
+                            >
+                                <div className="flex items-center justify-between">
+                                    <div
+                                        className="flex h-10 w-10 items-center justify-center rounded-xl"
+                                        style={{ backgroundColor: full ? '#f0f9f4' : '#f5f0e8' }}
+                                    >
+                                        <Folder size={18} style={{ color: full ? '#2a7d4f' : '#2d465e' }} />
+                                    </div>
+                                    <span
+                                        className="rounded-full px-2 py-0.5 text-[11px] font-semibold"
+                                        style={{
+                                            backgroundColor: full ? '#f0f9f4' : '#faf3ea',
+                                            color: full ? '#2a7d4f' : '#b45309',
+                                        }}
+                                    >
+                                        {folder.count}/{folder.capacity}
+                                    </span>
+                                </div>
+                                <div>
+                                    <p className="font-semibold" style={{ color: '#2d465e' }}>
+                                        {folder.name}
+                                    </p>
+                                    <p className="mt-1 text-xs" style={{ color: '#8a7f72' }}>
+                                        {full ? 'Carpeta completa' : `Faltan ${folder.capacity - folder.count}`}
+                                    </p>
+                                </div>
+                            </Link>
+                        );
+                    })}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\DevocionalAudioFolderController;
 use App\Http\Controllers\DevocionalController;
 use App\Http\Controllers\ShortUrlController;
 use App\Http\Controllers\EnsenanzaController;
@@ -177,6 +178,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/storage-cleanup', [StorageCleanupController::class, 'index'])->name('storage.cleanup');
     Route::get('/storage-cleanup/orphaned', [StorageCleanupController::class, 'orphaned'])->name('storage.orphaned');
     Route::delete('/storage-cleanup', [StorageCleanupController::class, 'destroy'])->name('storage.destroy');
+
+    Route::get('/devocionales-audio-folders', [DevocionalAudioFolderController::class, 'index'])->name('audio-folders.index');
+    Route::post('/devocionales-audio-folders/generate', [DevocionalAudioFolderController::class, 'generate'])->name('audio-folders.generate');
+    Route::post('/devocionales-audio-folders/move', [DevocionalAudioFolderController::class, 'move'])->name('audio-folders.move');
+    Route::get('/devocionales-audio-folders/{month}', [DevocionalAudioFolderController::class, 'show'])->whereNumber('month')->name('audio-folders.show');
+    Route::get('/devocionales-audio-folders/{month}/zip', [DevocionalAudioFolderController::class, 'downloadZip'])->whereNumber('month')->name('audio-folders.zip');
+    Route::get('/devocionales-audio-folders-audio/{id}', [DevocionalAudioFolderController::class, 'downloadAudio'])->name('audio-folders.audio');
+    Route::get('/devocionales-audio-folders-audio/{id}/url', [DevocionalAudioFolderController::class, 'audioUrl'])->name('audio-folders.audio-url');
 });
 
 Route::post('/upload-post-image', [ImageUploadController::class, 'post'])->middleware(['auth', 'verified']);


### PR DESCRIPTION
Admin tool to organize devocionales into 12 month folders (Jan=31, Feb=28, ... total 365 slots), one devocional per slot, no repeats.

- Migration: audio_folder_month/position on devocionals (unique slot pair), backed by DevocionalAudioFolderService.
- fillGaps() is a one-time backfill for pre-existing devocionales; new devocionales auto-assign to the next open slot on create via a model event, so the button never needs to run again.
- Per-devocional move-to-folder action closes the gap in the old month and appends at the end of the target, capacity-checked.
- Folder detail page: voice-selectable playback, per-item MP3 download (filename derived from content), and a ZIP export of the whole folder in position order.
- Cards reuse the existing CardNew + ae-card-* admin styling instead of a bespoke layout, for visual consistency with the rest of the admin panel.


Claude-Session: https://claude.ai/code/session_01FudAKZq9aQhvMT1mVo3Y3i